### PR TITLE
Update publications to fetch on load

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build
         run: npm run build # o el comando de compilación de tu proyecto Astro
         env:
-          ADS_API_KEY: ${{ secrets.ADS_API_KEY }}
+          PUBLIC_ADS_API_KEY: ${{ secrets.ADS_API_KEY }}
 
       - name: Upload Pages Artifact
         uses: actions/upload-pages-artifact@v3

--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -1,6 +1,5 @@
 ---
 import DefaultLayout from "../layouts/DefaultLayout.astro";
-import PublicationCard from "../components/PublicationCard.astro";
 
 interface ADSDoc {
   bibcode: string;
@@ -15,7 +14,7 @@ interface Publication {
   link: string;
 }
 
-const ADS_API_KEY = import.meta.env.ADS_API_KEY;
+const ADS_API_KEY = import.meta.env.PUBLIC_ADS_API_KEY;
 const LIBRARY_ID = "q7ce2driS9W-SkN3IcOqNA";
 
 async function fetchPublications(): Promise<Publication[]> {
@@ -68,20 +67,72 @@ async function fetchPublications(): Promise<Publication[]> {
   });
 }
 
-const publications = await fetchPublications();
 ---
 
 <DefaultLayout>
   <h2 class="text-3xl font-bold mb-4">Publicaciones</h2>
-  <div class="space-y-4">
-    {
-      publications.map((pub) => (
-        <PublicationCard
-          title={pub.title}
-          journal={pub.journal}
-          link={pub.link}
-        />
-      ))
+  <div id="publication-list" class="space-y-4"></div>
+  <script type="module">
+    const ADS_API_KEY = {JSON.stringify(ADS_API_KEY)};
+    const LIBRARY_ID = {JSON.stringify(LIBRARY_ID)};
+
+    async function fetchPublications() {
+      const params = new URLSearchParams({
+        fl: "bibcode,title,pub,year",
+        rows: "50",
+        sort: "date desc",
+      });
+
+      const res = await fetch(
+        `https://api.adsabs.harvard.edu/v1/biblib/libraries/${LIBRARY_ID}?${params}`,
+        {
+          headers: {
+            Authorization: `Bearer ${ADS_API_KEY}`,
+            Accept: "application/json",
+          },
+        }
+      );
+      if (!res.ok) {
+        console.error("Error ADS:", await res.text());
+        return [];
+      }
+
+      const { solr } = await res.json();
+      return solr.response.docs.map((doc) => {
+        let titleStr;
+        if (Array.isArray(doc.title) && doc.title.length > 0) {
+          titleStr = doc.title[0];
+        } else if (typeof doc.title === "string") {
+          titleStr = doc.title;
+        } else {
+          titleStr = doc.bibcode;
+        }
+
+        const journalStr =
+          doc.pub && doc.year ? `${doc.pub}, ${doc.year}` : doc.pub ?? "";
+
+        const link = `https://ui.adsabs.harvard.edu/abs/${doc.bibcode}/abstract`;
+        return { title: titleStr, journal: journalStr, link };
+      });
     }
-  </div>
+
+    async function loadPublications() {
+      const container = document.getElementById("publication-list");
+      container.textContent = "Cargando...";
+      try {
+        const pubs = await fetchPublications();
+        container.textContent = "";
+        for (const pub of pubs) {
+          const article = document.createElement("article");
+          article.className = "border-l-4 border-blue-600 pl-4";
+          article.innerHTML = `\n            <h3 class="text-xl font-semibold">\n              <a href="${pub.link}" target="_blank" class="hover:underline">${pub.title}</a>\n            </h3>\n            <p class="text-gray-700">${pub.journal}</p>`;
+          container.appendChild(article);
+        }
+      } catch (err) {
+        container.textContent = "Error al cargar publicaciones";
+      }
+    }
+
+    loadPublications();
+  </script>
 </DefaultLayout>


### PR DESCRIPTION
## Summary
- fetch publications on the client so new papers appear automatically
- expose ADS API key during the build step so the runtime script can call the API

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1d3803388322b95b98dd795bd4f5