### PR TITLE
Fix base path for Netlify deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,19 @@ Todos los comandos se ejecutan desde la raíz del proyecto:
 | `npm run astro ...` | Ejecuta comandos de la CLI de Astro como `astro add`, `astro check`       |
 
 **Nota importante sobre `base`:**
-Este proyecto está configurado con `base: '/RatLab/'` en [`astro.config.mjs`](astro.config.mjs). Esto significa que:
+Originalmente el proyecto estaba configurado con `base: '/RatLab/'` en
+[`astro.config.mjs`](astro.config.mjs) para ser publicado en un subdirectorio de
+GitHub Pages. Si lo despliegas en Netlify (o en la raíz de cualquier servidor)
+debes cambiar la opción a `base: '/'`; de lo contrario los estilos e imágenes no
+se cargarán correctamente.
 
-- En desarrollo, el sitio se sirve desde `http://localhost:4321/RatLab/`.
-- En producción (GitHub Pages), el sitio estará disponible en `https://<tu-usuario>.github.io/RatLab/`.
-  Los enlaces internos en los componentes (como en [`src/components/Navbar.astro`](src/components/Navbar.astro)) utilizan `import.meta.env.BASE_URL` para construir las rutas correctamente.
+- En desarrollo con `base: '/RatLab/'` el sitio se sirve desde
+  `http://localhost:4321/RatLab/`.
+- En producción (por ejemplo GitHub Pages) el sitio estará disponible en
+  `https://<tu-usuario>.github.io/RatLab/`.
+  Los enlaces internos en los componentes (como en
+  [`src/components/Navbar.astro`](src/components/Navbar.astro)) utilizan
+  `import.meta.env.BASE_URL` para construir las rutas correctamente.
 
 ## 🚀 Despliegue
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,10 +4,12 @@ import tailwind from '@astrojs/tailwind';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
-  // URL pública de tu sitio (sin slash al final)
-  site: 'https://tu-usuario.github.io/RatLab',
-  // ruta base para todas las páginas
-  base: '/RatLab/',
+  // URL pública de tu sitio (sin slash al final). Actualiza esta URL con el
+  // dominio de tu deployment en Netlify o el que prefieras.
+  site: 'https://your-site.netlify.app',
+  // Ruta base para todas las páginas. Para Netlify debe ser la raíz `/` para
+  // que los estilos e imágenes se resuelvan correctamente.
+  base: '/',
   output: 'static',
   integrations: [
     tailwind(),


### PR DESCRIPTION
## Summary
- update `astro.config.mjs` to use `/` as base and add a note about setting the site URL
- document the change in README so deployments on Netlify load assets correctly

## Testing
- `npm install` *(fails: unable to reach registry)*
- `npm run build` *(fails: astro not found because install failed)*

------
https://chatgpt.com/codex/tasks/task_e_685f27a2fd7c8322b88477533b215fd7